### PR TITLE
Pre-Commit Hooks Automation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8

--- a/backend/tweets/datasets.py
+++ b/backend/tweets/datasets.py
@@ -80,6 +80,7 @@ DATA_MAP = {
     ),
 }
 
+
 # %% Twitter Dataset
 def load_tweets() -> Dataset:
     """Load the Tweets Dataset"""

--- a/docs/dev/dev_guidelines.md
+++ b/docs/dev/dev_guidelines.md
@@ -3,6 +3,24 @@
 
 The **Backlog** of Repo changes and activities can be found here: [backlog.md](backlog.md)  
 
+## Pre-commit
+
+In order to automate the `black` and `flake8` code formatting, integration with 
+the Python `pre-commit` package has been added to this repo. 
+
+To do so, it is just necessary to:
+
+1. Install `pre-commit` Python package 
+    (already **included** in the `requirements.txt` file):
+    ```shell script
+    pip install pre-commit
+    ```
+
+2. Install the git hooks in your `./git/hooks` directory:
+    ```shell script
+    pre-commit install
+    ``` 
+
 ---
 If you would like to contribute to the project, please follow the guidelines below: 
 
@@ -112,17 +130,3 @@ python -m ipykernel install --user --name covid-community --display-name "Python
 ```
 
 Further information [here](https://ipython.readthedocs.io/en/stable/install/kernel_install.html)
-
-#### Code formatting
-
-If possible, use the [black code formatter](https://github.com/python/black) (e.g.
-`pip install black`) and run it before submitting your code to the repository. 
-This helps maintain consistency.
-
-Formatting is as simple as running:
-
-```bash
-black .
-```
-
-in the root of the project.

--- a/docs/dev/requirements.txt
+++ b/docs/dev/requirements.txt
@@ -26,5 +26,4 @@ requests==2.23.0
 requests-oauthlib==1.3.0
 tweet-preprocessor==0.5.0
 # Code Formatting Integration
-black>=19.10b0
 pre-commit

--- a/docs/dev/requirements.txt
+++ b/docs/dev/requirements.txt
@@ -24,5 +24,7 @@ lxml==4.5.0
 oauthlib==3.1.0
 requests==2.23.0
 requests-oauthlib==1.3.0
-black>=19.10b0  # code formatting
 tweet-preprocessor==0.5.0
+# Code Formatting Integration
+black>=19.10b0
+pre-commit


### PR DESCRIPTION
This PR Integrates `pre-commit` dependency and automation in the development workflow - as presented live during the Lab meeting. 

This includes an extra requirements (i.e. `pre-commit` itself) - and dropped `black`, no more needed thanks to automation.

Pre-commit has been configured to use `black` and `flake8` for code formatting and listing. 

Instructions on how to use `pre-commit` has been added to the dev documentation in the repo - also included in this PR.
